### PR TITLE
Require rspec/matchers in matchers file

### DIFF
--- a/lib/rspec/query_limit/matchers.rb
+++ b/lib/rspec/query_limit/matchers.rb
@@ -1,3 +1,5 @@
+require 'rspec/matchers'
+
 module Rspec
   module QueryLimit
     RSpec::Matchers.define :query_limit_eq do |expected|


### PR DESCRIPTION
Without this I was getting error `NameError: uninitialized constant RSpec::Matchers`
